### PR TITLE
Change ProgressIndicator in DynamicIsland from struct to final class

### DIFF
--- a/Sources/DynamicIslandUtilities/DynamicIsland+ProgressIndicator.swift
+++ b/Sources/DynamicIslandUtilities/DynamicIsland+ProgressIndicator.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 extension DynamicIsland {
-  public struct ProgressIndicator {
+  public final class ProgressIndicator {
     private let progressIndicatorImpl: DynamicIslandProgressIndicatorImplementation
     
     init () {


### PR DESCRIPTION
Hi!
Thx for your awesome codes for Dynamic Island :]

I just figured it out that it's better to change `ProgressIndicator` which is implemented in `extension DynamicIsland`.
Since the property `progressIndicator` is declared as let property which is struct, it's impossible to allocate new values for properties in `progressIndicator` as README.md you wrote.

<img width="750" alt="image" src="https://user-images.githubusercontent.com/58765757/218293440-f720ec49-f1b6-4649-82e4-c589de232761.png">

We can make `progressIndicator` var as well, but I thought this way is better(But it's your call of course!).

I hope it's not my misunderstanding and can help u even though it's just a little thingy ☺️

Plz let me know if there are any changes you need more or this PR is not needed.
Thx again!

### README.md
> A simple object that provides access to a progress indicator around the Dynamic Island cutout. 
To use it, simply access DynamicIsland.progressIndicator from anywhere to control the indicator.

> DynamicIsland.progressIndicator.progressColor = .green
> DynamicIsland.progressIndicator.isProgressIndeterminate = false

